### PR TITLE
Add the instance type an.g1.a100sxm.kube.x1

### DIFF
--- a/infra/tf/fake-operator-ready.tf
+++ b/infra/tf/fake-operator-ready.tf
@@ -87,6 +87,7 @@ resource "kubernetes_daemonset" "fake_toolkit_ready" {
                     "an.g1.h100.kube.x2",
                     "an.g1.h100.kube.x4",
                     "an.g1.h100.kube.x8",
+                    "an.g1.a100sxm.kube.x1",
                     "an.g1.h200sxm.kube.x1",
                     "an.g1.h200sxm.kube.x8"
                   ]

--- a/infra/tf/values/gpu-operator-values.yaml
+++ b/infra/tf/values/gpu-operator-values.yaml
@@ -61,6 +61,7 @@ node-feature-discovery:
                     - an.g1.h100.kube.x2
                     - an.g1.h100.kube.x4
                     - an.g1.h100.kube.x8
+                    - an.g1.a100sxm.kube.x1
                     - an.g1.h200sxm.kube.x1
                     - an.g1.h200sxm.kube.x8
     tolerations:
@@ -98,13 +99,14 @@ node-feature-discovery:
                     - an.g1.h100.kube.x2
                     - an.g1.h100.kube.x4
                     - an.g1.h100.kube.x8
+                    - an.g1.a100sxm.kube.x1
                     - an.g1.h200sxm.kube.x1
                     - an.g1.h200sxm.kube.x8
     tolerations:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
-  
+
 ## Driver configuration
 driver:
   enabled: false
@@ -147,7 +149,7 @@ dcgm:
 dcgmExporter:
   # enable with monitoring
   enabled: false
-  
+
 ## MIG Manager configuration.
 migManager:
   ## @skip civo-talos-gpu-operator.migManager.enabled


### PR DESCRIPTION
## WHAT

Added `an.g1.a100sxm.kube.x`1 to the list of allowed instance types so the components can be scheduled correctly.

## WHY

Components were not deployed on `an.g1.a100sxm.kube.x1` nodes because this instance type was missing from the nodeAffinity settings.